### PR TITLE
feat(auth): serve the configurable logout route in handle

### DIFF
--- a/packages/auth/spec/kavach-server.spec.js
+++ b/packages/auth/spec/kavach-server.spec.js
@@ -230,3 +230,88 @@ describe('kavach.handle — Response body serialization', () => {
 		expect(body).toHaveProperty('session')
 	})
 })
+
+describe('kavach.handle — logout route', () => {
+	beforeEach(() => {
+		global.Response = OriginalResponse
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	function makeAdapter() {
+		return {
+			synchronize: vi.fn(),
+			signOut: vi.fn().mockResolvedValue(undefined),
+			onAuthChange: vi.fn(),
+			parseUrlError: vi.fn(() => null),
+			signIn: vi.fn(),
+			signUp: vi.fn()
+		}
+	}
+
+	it('signs out, clears the session cookie, and redirects to login', async () => {
+		const { createKavach } = await import('../src/kavach.js')
+		const adapter = makeAdapter()
+		const kavachInstance = createKavach(adapter, {
+			app: { login: '/signin', logout: '/logout', session: '/auth/session' },
+			rules: []
+		})
+		const mockEvent = {
+			url: new URL('http://localhost/logout'),
+			cookies: { get: vi.fn(() => 'undefined') },
+			locals: {},
+			request: { method: 'GET' }
+		}
+
+		const result = await kavachInstance.handle({ event: mockEvent, resolve: vi.fn() })
+
+		expect(adapter.signOut).toHaveBeenCalled()
+		expect(result.status).toBe(303)
+		expect(result.headers.get('location')).toBe('http://localhost/signin')
+		expect(result.headers.get('set-cookie')).toBeTruthy()
+	})
+
+	it('serves a custom configured logout path', async () => {
+		const { createKavach } = await import('../src/kavach.js')
+		const adapter = makeAdapter()
+		const kavachInstance = createKavach(adapter, {
+			app: { login: '/signin', logout: '/sign-out', session: '/auth/session' },
+			rules: []
+		})
+		const mockEvent = {
+			url: new URL('http://localhost/sign-out'),
+			cookies: { get: vi.fn(() => 'undefined') },
+			locals: {},
+			request: { method: 'GET' }
+		}
+
+		const result = await kavachInstance.handle({ event: mockEvent, resolve: vi.fn() })
+
+		expect(adapter.signOut).toHaveBeenCalled()
+		expect(result.status).toBe(303)
+		expect(result.headers.get('location')).toBe('http://localhost/signin')
+	})
+
+	it('does not intercept a non-logout path (falls through to protection)', async () => {
+		const { createKavach } = await import('../src/kavach.js')
+		const adapter = makeAdapter()
+		const resolve = vi.fn(() => 'RESOLVED')
+		const kavachInstance = createKavach(adapter, {
+			app: { login: '/signin', logout: '/logout', session: '/auth/session' },
+			rules: [{ path: '/', public: true }]
+		})
+		const mockEvent = {
+			url: new URL('http://localhost/'),
+			cookies: { get: vi.fn(() => 'undefined') },
+			locals: {},
+			request: { method: 'GET' }
+		}
+
+		const result = await kavachInstance.handle({ event: mockEvent, resolve })
+
+		expect(adapter.signOut).not.toHaveBeenCalled()
+		expect(result).toBe('RESOLVED')
+	})
+})

--- a/packages/auth/src/kavach.js
+++ b/packages/auth/src/kavach.js
@@ -206,6 +206,29 @@ async function handleSessionSync(event, adapter, sentry) {
 }
 
 /**
+ * Handle a hit on the configured logout route (`app.logout`, default `/logout`).
+ * Signs the user out server-side, clears the session cookie, and redirects to
+ * the login route — so a plain `<a href>` to the declared, configurable
+ * `routes.logout` just works, with no per-app endpoint. Mirrors the served
+ * `session` route; reuses `setCookieFromSession(null)` to clear the cookie (the
+ * same mechanism the session route uses on sign-out).
+ *
+ * @param {object} event
+ * @param {import('kavach').AuthAdapter} adapter
+ * @param {import('kavach').Sentry} sentry
+ * @returns {Promise<Response>}
+ */
+async function handleLogout(event, adapter, sentry) {
+	await adapter.signOut()
+	sentry.setSession(null)
+	const headers = setCookieFromSession(null)
+	return new Response('', {
+		status: 303,
+		headers: { ...headers, location: event.url.origin + (sentry.app.login ?? '/') }
+	})
+}
+
+/**
  * Parse session from cookies
  *
  * @param {object}   event
@@ -248,6 +271,10 @@ function handleRouteProtection(adapter, agents, { event, resolve }) {
 
 	if (sentry.app.session && pathname.startsWith(sentry.app.session)) {
 		return handleSessionSync(event, adapter, sentry)
+	}
+
+	if (sentry.app.logout && pathname.startsWith(sentry.app.logout)) {
+		return handleLogout(event, adapter, sentry)
 	}
 
 	if (agents.dataFn && sentry.app.data && isDataRoute(pathname, sentry.app.data)) {


### PR DESCRIPTION
Closes #23.

## What
`handleRouteProtection` now serves the declared, configurable `logout` route (default `/logout`, set via `routes.logout`) — the same way it already serves `session`/`data`/`rpc`. On a hit it signs out server-side, clears the session cookie (`setCookieFromSession(null)`), and 303-redirects to `app.login`.

Before this, `routes.logout` was declarative only: a plain `<a href="/logout">` fell through to app routing and 404'd, so every app had to hand-roll an endpoint or a client `signOut()` button.

## Changes
- `packages/auth/src/kavach.js`: new `handleLogout()` + a branch in `handleRouteProtection` after the session branch.
- `packages/auth/spec/kavach-server.spec.js`: 3 tests — signout+clear-cookie+303→login, custom logout path, and non-logout paths still fall through to protection.

## Notes
- `packages/vite/src/generate.js` already maps `routes.logout → app.logout`, so it's configurable end-to-end with no further change.
- Reuses the existing cookie-clear (same as the session route's sign-out branch).
- Backward compatible: apps with their own `/logout` route can repoint `routes.logout`.
- Full suite: 723 passing; lint 0 errors.